### PR TITLE
Add CSP rule for Unveild

### DIFF
--- a/hydrogen-quickstart/app/entry.server.jsx
+++ b/hydrogen-quickstart/app/entry.server.jsx
@@ -40,6 +40,7 @@ export default async function handleRequest(
       'https://production.cdp.ingest.chord.co',
       'https://www.googletagmanager.com',
       'https://www.google-analytics.com',
+      'https://sneakpeek-1.s3.us-east-1.amazonaws.com',
     ],
   });
 


### PR DESCRIPTION
Adds a CSP rules to allow the Hydrogen demo site to load scripts from Unveild.