### PR TITLE
Fix/custom cart attributes

### DIFF
--- a/hydrogen-quickstart/app/components/CartSummary.jsx
+++ b/hydrogen-quickstart/app/components/CartSummary.jsx
@@ -8,8 +8,6 @@ export function CartSummary({cart, layout}) {
   const className =
     layout === 'page' ? 'cart-summary-page' : 'cart-summary-aside';
 
-  // console.log(cart);
-
   return (
     <div aria-labelledby="cart-summary" className={className}>
       <h4>Totals</h4>
@@ -33,23 +31,13 @@ export function CartSummary({cart, layout}) {
 export default function AttributeUpdateForm() {
   const [sscid, setSscid] = useState('');
   useEffect(() => {
-    // Submit the form automatically on mount
-
-    // Read the 'sscid' value from browser cookies
-    function getCookieValue(name) {
-      if (typeof document === 'undefined') return '';
-      const match = document.cookie.match(
-        new RegExp('(^| )' + name + '=([^;]+)'),
-      );
-      return match ? decodeURIComponent(match[2]) : '';
-    }
-
-    setSscid(getCookieValue('sscid'));
+    const urlParams = new URLSearchParams(window.location.search);
+    setSscid(urlParams.get('sscid') || '');
 
     if (!sscid) {
       return;
     }
-    // Trigger a click on the update-attributes-button button
+
     const button = document.getElementById('update-attributes-button');
     if (button) {
       button.click();

--- a/hydrogen-quickstart/app/routes/cart.jsx
+++ b/hydrogen-quickstart/app/routes/cart.jsx
@@ -45,6 +45,7 @@ export async function action({request, context}) {
       break;
     case CartForm.ACTIONS.DiscountCodesUpdate: {
       const formDiscountCode = inputs.discountCode;
+
       // User inputted discount code
       const discountCodes = formDiscountCode ? [formDiscountCode] : [];
 


### PR DESCRIPTION
This silently adds cart attributes based on the value of sscid in URL search params. This was needed during development of our Share A Sale CDP destination which can be found here: https://github.com/chordcommerce/jitsu/pull/83