### PR TITLE
Add SKU and image_url handling 

### DIFF
--- a/hydrogen-quickstart/app/lib/chord.js
+++ b/hydrogen-quickstart/app/lib/chord.js
@@ -18,6 +18,7 @@ const productFormatter = ({position, product, quantity, variantId}) => {
     slug: product?.handle,
     variant: product?.variantTitle,
     variant_id: parseGid(variantId)?.id || undefined,
+    image_url: product?.image,
   };
 };
 

--- a/hydrogen-quickstart/app/routes/products.$handle.jsx
+++ b/hydrogen-quickstart/app/routes/products.$handle.jsx
@@ -164,6 +164,8 @@ export default function Product() {
               variantId: selectedVariant?.id || '',
               variantTitle: selectedVariant?.title || '',
               quantity: 1,
+              sku: selectedVariant?.sku,
+              image: product?.selectedOrFirstAvailableVariant?.image.url,
             },
           ],
         }}


### PR DESCRIPTION
Updates payload sent to Hydrogen product_viewed event and also adds image_url field to product formatter.

<img width="261" height="213" alt="image" src="https://github.com/user-attachments/assets/01e7bfb8-b066-453d-9010-48b2ebc391c5" />
